### PR TITLE
BUG: flexmail api does not accept upercase letters in email address

### DIFF
--- a/src/services/Contact.php
+++ b/src/services/Contact.php
@@ -28,9 +28,9 @@ class Contact extends Component
 
     public function createOrUpdateContact($email, $language, $source = null, $firstName = null, $lastName = null, $customFields = [], $interests = [], $labels = [], $preferences = [])
     {
-//        TODO: Set default source in settings? Sources like lists?
+        //        TODO: Set default source in settings? Sources like lists?
         $fields = [
-            'email' => $email,
+            'email' => strtolower($email), // INFO: flexmail does not accept uppercase email addresses
             'first_name' => $firstName ?? null,
             'name' => $lastName ?? null,
             'language' => $language,
@@ -86,10 +86,11 @@ class Contact extends Component
                         $contact[$key][$k] = $data[$key][$k];
                     }
                 }
-            } else if (isset($data[$key]) && $data[$key]) {
+            } elseif (isset($data[$key]) && $data[$key]) {
                 $contact[$key] = $data[$key];
             }
         }
         return $contact;
     }
 }
+


### PR DESCRIPTION
See screenshot of error message when trying to upload email with capitalization.

edited: removed image which showed the flexmail error message explaining you can't have capitalization because it contained personal data i looked over. 